### PR TITLE
Fix jlink search path for people who aren't Jason

### DIFF
--- a/wscript
+++ b/wscript
@@ -371,10 +371,6 @@ def get_jlink_srch_path(exe_name: str):
     # JLink installer gives the option to update the "current instance", which
     # is installed under the "Jlink" subfolder. Otherwise it installs a version
     # specific folder.
-    return [
-            "C:\\Program Files\\SEGGER\\JLink",
-            "D:\\SEGGER\\JLink_V798i",
-        ] + paths
 
     install_roots = []
     jlink_installs = []
@@ -384,7 +380,7 @@ def get_jlink_srch_path(exe_name: str):
         install_roots = [
             "C:\\Program Files\\SEGGER\\",
             "C:\\Program Files (x86)\\SEGGER\\",
-            "D:\\SEGGER\\JLink_V798i",
+            "D:\\SEGGER\\",
         ]
 
     elif Utils.unversioned_sys_platform() == "darwin":


### PR DESCRIPTION
The hardcoded paths won't work on Mac/Linux, and either require an install to the D drive or the option to have updated the existing installation to have been chosen (the tutorial specifically says not to do this).

Restores the old logic for checking all installations found in particular folders. Adjusts the D: path so that it should work on Jason's setup given the hardcoded paths that were present.