### PR TITLE
Added tasks for waf build/configure and git clean

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,7 +12,8 @@
         "spadin.config-defaults",
         "mhutchie.git-graph",
         "eamodio.gitlens",
-        "ms-vscode.vscode-serial-monitor"
+        "ms-vscode.vscode-serial-monitor",
+        "forbeslindesay.forbeslindesay-taskrunner"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,25 +2,128 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-    "tasks": [
+    "tasks":
+    [
         {
-            "label": "Build firmware",
+            "label": "[waf] configure ASCII",
             "type": "process",
             "command": "python",
-            "args": [
+            "args":
+            [
                 "waf",
-                "build",
-                "--keep", // Keep going even if error, ensures all compilation failures are found.
+                "configure",
+                "--board=ASCII",
             ],
             "isBuildCommand": true,
-            "problemMatcher": {
+            "problemMatcher":
+            {
                 "base": "$gcc",
-                "fileLocation": [
+                "fileLocation":
+                [
                     "autoDetect",
                     "${workspaceFolder}/build/",
                 ]
             },
-            "options": {
+            "options":
+            {
+                "cwd": "${workspaceFolder}",
+            },
+        },
+        {
+            "label": "[waf] configure DOT_MATRIX",
+            "type": "process",
+            "command": "python",
+            "args":
+            [
+                "waf",
+                "configure",
+                "--board=DOT_MATRIX",
+            ],
+            "isBuildCommand": true,
+            "problemMatcher":
+            {
+                "base": "$gcc",
+                "fileLocation":
+                [
+                    "autoDetect",
+                    "${workspaceFolder}/build/",
+                ]
+            },
+            "options":
+            {
+                "cwd": "${workspaceFolder}",
+            },
+        },
+        {
+            "label": "[waf] build",
+            "type": "process",
+            "command": "python",
+            "args":
+            [
+                "waf",
+                "build",
+            ],
+            "isBuildCommand": true,
+            "problemMatcher":
+            {
+                "base": "$gcc",
+                "fileLocation":
+                [
+                    "autoDetect",
+                    "${workspaceFolder}/build/",
+                ]
+            },
+            "options":
+            {
+                "cwd": "${workspaceFolder}",
+            },
+        },
+        {
+            "label": "[waf] build & flash",
+            "type": "process",
+            "command": "python",
+            "args":
+            [
+                "waf",
+                "build",
+                "-F",
+            ],
+            "isBuildCommand": true,
+            "problemMatcher":
+            {
+                "base": "$gcc",
+                "fileLocation":
+                [
+                    "autoDetect",
+                    "${workspaceFolder}/build/",
+                ]
+            },
+            "options":
+            {
+                "cwd": "${workspaceFolder}",
+            },
+        },
+        {
+            "label": "[git] clean workspace",
+            "type": "process",
+            "command": "git",
+            "args":
+            [
+                "clean",
+                "-diX",
+            ],
+            "isBuildCommand": true,
+            "problemMatcher":
+            {
+                "base": "$gcc",
+                "fileLocation":
+                [
+                    "autoDetect",
+                    "${workspaceFolder}/build/",
+                ]
+            },
+            "options":
+            {
                 "cwd": "${workspaceFolder}",
             },
         }


### PR DESCRIPTION
With the [TaskRunner](https://marketplace.visualstudio.com/items?itemName=forbeslindesay.forbeslindesay-taskrunner) extension, all the WAF commands can become one-click to run.

![image](https://github.com/user-attachments/assets/572faced-9ce4-457c-8e92-7b6f8d52dd74)


